### PR TITLE
feat(trailer): embed trailer player in movie and TV show modals

### DIFF
--- a/app/(modals)/movie/[id].tsx
+++ b/app/(modals)/movie/[id].tsx
@@ -16,11 +16,12 @@ export default function MovieDetailsModal() {
       tmdbId={movie?.id}
       mediaType="movie"
       overview={movie?.overview}
+      trailerKey={movie?.trailerKey}
     >
-      <Text className="font-bold color-white text-2xl self-center">
+      <Text className="font-bold color-white text-2xl w-full text-center">
         {movie?.title}
       </Text>
-      <Text className="mt-2 color-white text-lg self-center">
+      <Text className="mt-2 color-white text-lg w-full text-center">
         Movie • {movie?.releaseDate?.split("-")[0]}
       </Text>
     </MediaDetailModal>

--- a/app/(modals)/tv-show/[id].tsx
+++ b/app/(modals)/tv-show/[id].tsx
@@ -16,11 +16,12 @@ export default function TvShowDetailsModal() {
       tmdbId={show?.id}
       mediaType="tv-show"
       overview={show?.overview}
+      trailerKey={show?.trailerKey}
     >
-      <Text className="font-bold color-white text-2xl self-center">
+      <Text className="font-bold color-white text-2xl w-full text-center">
         {show?.name}
       </Text>
-      <Text className="mt-2 color-white text-lg self-center">
+      <Text className="mt-2 color-white text-lg w-full text-center">
         TV show • {show?.firstAirDate?.split("-")[0]}
       </Text>
     </MediaDetailModal>

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,9 @@
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
         "react-native-web": "~0.21.0",
+        "react-native-webview": "13.15.0",
         "react-native-worklets": "0.5.1",
+        "react-native-youtube-iframe": "^2.4.1",
         "tailwindcss": "^3.4.19"
       },
       "devDependencies": {
@@ -6987,6 +6989,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/exec-async": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/exec-async/-/exec-async-2.2.0.tgz",
@@ -13603,6 +13614,21 @@
       "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
       "license": "MIT"
     },
+    "node_modules/react-native-webview": {
+      "version": "13.15.0",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.15.0.tgz",
+      "integrity": "sha512-Vzjgy8mmxa/JO6l5KZrsTC7YemSdq+qB01diA0FqjUTaWGAGwuykpJ73MDj3+mzBSlaDxAEugHzTtkUQkQEQeQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "invariant": "2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-worklets": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.5.1.tgz",
@@ -13637,6 +13663,29 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/react-native-youtube-iframe": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/react-native-youtube-iframe/-/react-native-youtube-iframe-2.4.1.tgz",
+      "integrity": "sha512-MIzVlQYp6sc/Z7b0YwluALd0UbACQ7vscpcVVTmcHvQ5ujN2f6LJdDFxI++xy7TUeJS73k8vBdlznb5bT/P/Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "events": "^3.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.6",
+        "react-native": ">=0.60",
+        "react-native-web-webview": ">=1.0.2",
+        "react-native-webview": ">=7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web-webview": {
+          "optional": true
+        },
+        "react-native-webview": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-native/node_modules/@react-native/virtualized-lists": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
     "react-native-web": "~0.21.0",
+    "react-native-webview": "13.15.0",
     "react-native-worklets": "0.5.1",
+    "react-native-youtube-iframe": "^2.4.1",
     "tailwindcss": "^3.4.19"
   },
   "devDependencies": {

--- a/src/features/movies/types.ts
+++ b/src/features/movies/types.ts
@@ -6,4 +6,5 @@ export type Movie = {
   posterPath: string;
   backdropPath: string;
   voteAverage: number;
+  trailerKey: string;
 };

--- a/src/features/movies/types.ts
+++ b/src/features/movies/types.ts
@@ -6,5 +6,5 @@ export type Movie = {
   posterPath: string;
   backdropPath: string;
   voteAverage: number;
-  trailerKey: string;
+  trailerKey?: string;
 };

--- a/src/features/tv-shows/types.ts
+++ b/src/features/tv-shows/types.ts
@@ -6,4 +6,5 @@ export type TvShow = {
   posterPath: string;
   backdropPath: string;
   voteAverage: number;
+  trailerKey: string;
 };

--- a/src/features/tv-shows/types.ts
+++ b/src/features/tv-shows/types.ts
@@ -6,5 +6,5 @@ export type TvShow = {
   posterPath: string;
   backdropPath: string;
   voteAverage: number;
-  trailerKey: string;
+  trailerKey?: string;
 };

--- a/src/shared/components/MediaDetailModal.tsx
+++ b/src/shared/components/MediaDetailModal.tsx
@@ -1,5 +1,5 @@
 import { useWatchlistContext } from "@features/watchlist/components/WatchlistContext";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 import {
   ActivityIndicator,
   Animated,
@@ -40,7 +40,7 @@ export default function MediaDetailModal({
   const textOpacity = useRef(new Animated.Value(0)).current;
   const hasAnimatedRef = useRef(false);
   const { add, remove, isInWatchlist } = useWatchlistContext();
-  const [playing] = useState(false);
+  const playing = false;
   const { width } = useWindowDimensions();
   const trailerHeight = Math.round((width * 9) / 16);
 

--- a/src/shared/components/MediaDetailModal.tsx
+++ b/src/shared/components/MediaDetailModal.tsx
@@ -1,5 +1,5 @@
 import { useWatchlistContext } from "@features/watchlist/components/WatchlistContext";
-import React, { useCallback, useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,
   Animated,
@@ -7,9 +7,11 @@ import {
   ScrollView,
   Text,
   TouchableOpacity,
+  useWindowDimensions,
   View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import YoutubePlayer from "react-native-youtube-iframe";
 
 type MediaDetailModalProps = {
   id: string;
@@ -19,6 +21,7 @@ type MediaDetailModalProps = {
   tmdbId?: number;
   mediaType: "movie" | "tv-show";
   overview?: string;
+  trailerKey?: string;
   children?: React.ReactNode;
 };
 
@@ -30,12 +33,16 @@ export default function MediaDetailModal({
   tmdbId,
   mediaType,
   overview,
+  trailerKey,
   children,
 }: MediaDetailModalProps) {
   const imageOpacity = useRef(new Animated.Value(0)).current;
   const textOpacity = useRef(new Animated.Value(0)).current;
   const hasAnimatedRef = useRef(false);
   const { add, remove, isInWatchlist } = useWatchlistContext();
+  const [playing] = useState(false);
+  const { width } = useWindowDimensions();
+  const trailerHeight = Math.round((width * 9) / 16);
 
   useEffect(() => {
     hasAnimatedRef.current = false;
@@ -74,17 +81,35 @@ export default function MediaDetailModal({
       ) : (
         <ScrollView contentContainerStyle={{ paddingBottom: 80 }}>
           <View>
-            <Animated.View style={{ opacity: imageOpacity }}>
-              <Image
-                source={{
-                  uri: `https://image.tmdb.org/t/p/original${backdropPath}`,
-                }}
-                className="w-full aspect-video"
-                onLoadEnd={runIntro}
-              />
-            </Animated.View>
+            {!trailerKey ? (
+              <Animated.View style={{ opacity: imageOpacity }}>
+                <Image
+                  source={{
+                    uri: `https://image.tmdb.org/t/p/original${backdropPath}`,
+                  }}
+                  className="w-full aspect-video"
+                  onLoadEnd={runIntro}
+                />
+              </Animated.View>
+            ) : (
+              <Animated.View style={{ opacity: imageOpacity }}>
+                <View
+                  style={{ height: trailerHeight, overflow: "hidden" }}
+                  className="w-full"
+                >
+                  <YoutubePlayer
+                    height={trailerHeight}
+                    width={width}
+                    play={playing}
+                    videoId={trailerKey}
+                    onReady={runIntro}
+                  />
+                </View>
+              </Animated.View>
+            )}
+
             <Animated.View
-              className="flex-col items-start justify-center mt-5 px-5"
+              className="flex-col items-center justify-center mt-5 px-5"
               style={{ opacity: textOpacity }}
             >
               {children}


### PR DESCRIPTION
Closes #15

## Summary
- Adds `trailerKey` field to `Movie` and `TvShow` types
- Both detail modals pass `trailerKey` from the fetched object to `MediaDetailModal`
- `MediaDetailModal` renders a YouTube player (`react-native-youtube-iframe`) when `trailerKey` is present, falls back to the backdrop image when absent
- No separate trailer endpoint — trailer data comes embedded in the existing media object

## Test plan
- [x] Open a movie with a trailer → YouTube player appears at the top of the modal
- [x] Open a movie without a trailer → backdrop image appears instead
- [x] Open a TV show with a trailer → same behaviour
- [x] Open a TV show without a trailer → backdrop image fallback
- [x] Switching between modals does not leak trailer state